### PR TITLE
Executes load after fetch

### DIFF
--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -264,7 +264,8 @@ export class MastStream extends LitElement {
       throw new Error("missing stream id");
     }
     console.log("Fetching...");
-    backend.fetch(stid);
+    await backend.fetch(stid);
+    this.loadNext();
   }
 
   updateStatusRef(item: StatusItem, elt?: Element) {


### PR DESCRIPTION
It seems awkward to need to have to click two buttons when wanting new content, so let's not do that.