### PR TITLE
Add emoji shortcode in image title

### DIFF
--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -590,6 +590,7 @@ function expandEmojis(msg: string, emojis?: mastodon.CustomEmoji[]): TemplateRes
         img.setAttribute('class', 'emoji');
         img.setAttribute('src', emoji.url);
         img.setAttribute('alt', `emoji ${emoji.shortcode}`);
+        img.setAttribute('title', `emoji ${emoji.shortcode}`);
         parent.insertBefore(doc.createTextNode(txt.substring(prevMatchEnd, match.index)), node)
         parent.insertBefore(img, node);
         prevMatchEnd = match.index + match[0].length;


### PR DESCRIPTION
Adding the emoji shortcode in the title enables showing it on hover (which makes :randomtinyimage: more readable)